### PR TITLE
feat: 전체적인 레이아웃 틀 잡기, feat: 버튼 컴포넌트 생성, feat: 메인화면 내 서재 섹션 슬라이드 기능 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "prettier": "^3.2.5",
         "react": "^18",
         "react-dom": "^18",
+        "react-responsive-carousel": "^3.2.23",
         "recoil": "^0.7.7"
       },
       "devDependencies": {
@@ -1229,6 +1230,11 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow=="
     },
     "node_modules/client-only": {
       "version": "0.0.1",
@@ -3906,10 +3912,31 @@
         "react": "^18.2.0"
       }
     },
+    "node_modules/react-easy-swipe": {
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/react-easy-swipe/-/react-easy-swipe-0.0.21.tgz",
+      "integrity": "sha512-OeR2jAxdoqUMHIn/nS9fgreI5hSpgGoL5ezdal4+oO7YSSgJR8ga+PkYGJrSrJ9MKlPcQjMQXnketrD7WNmNsg==",
+      "dependencies": {
+        "prop-types": "^15.5.8"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "node_modules/react-responsive-carousel": {
+      "version": "3.2.23",
+      "resolved": "https://registry.npmjs.org/react-responsive-carousel/-/react-responsive-carousel-3.2.23.tgz",
+      "integrity": "sha512-pqJLsBaKHWJhw/ItODgbVoziR2z4lpcJg+YwmRlSk4rKH32VE633mAtZZ9kDXjy4wFO+pgUZmDKPsPe1fPmHCg==",
+      "dependencies": {
+        "classnames": "^2.2.5",
+        "prop-types": "^15.5.8",
+        "react-easy-swipe": "^0.0.21"
+      }
     },
     "node_modules/read-cache": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "prettier": "^3.2.5",
     "react": "^18",
     "react-dom": "^18",
+    "react-responsive-carousel": "^3.2.23",
     "recoil": "^0.7.7"
   },
   "devDependencies": {

--- a/src/app/assets/data/bookdummy.tsx
+++ b/src/app/assets/data/bookdummy.tsx
@@ -1,0 +1,50 @@
+export const slideData = [
+    {
+        id:1,
+        title:'책1',
+        content:'재밌게 읽었다',
+        src:'',
+        alt: "image1",
+        path:'/'
+    },
+    {
+        id:2,
+        title:'책2',
+        content:'재미없고 지루했다',
+        src:'',
+        alt: "image2",
+        path:'/'
+    },
+    {
+        id:3,
+        title:'책3',
+        content:'흥미로웠다',
+        src:'',
+        alt: "image3",
+        path:'/'
+    },
+    {
+        id:4,
+        title:'책4',
+        content:'무섭고 소름돋았다',
+        src:'',
+        alt: "image1",
+        path:'/'
+    },
+    {
+        id:5,
+        title:'책5',
+        content:'재미없고 지루했다',
+        src:'',
+        alt: "image2",
+        path:'/'
+    },
+    {
+        id:6,
+        title:'책6',
+        content:'따뜻한 커피 한잔과 여유',
+        src:'',
+        alt: "image3",
+        path:'/'
+    },
+]

--- a/src/app/components/Layout/Page.tsx
+++ b/src/app/components/Layout/Page.tsx
@@ -1,0 +1,16 @@
+import NavBar from "../navBar";
+
+
+
+const LayOut = (props:any) => {
+    return (
+        <div className="min-h-full">
+        <NavBar/>
+        <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+            <main>{props.children}</main>
+        </div>
+    </div>
+    )
+}
+
+export default LayOut;

--- a/src/app/components/buttons/button.tsx
+++ b/src/app/components/buttons/button.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+
+
+interface ButtonProps {
+    label:string;
+    onClick?:( e:React.MouseEvent<HTMLButtonElement>) => void;
+    disabled?:boolean;
+    outline?:boolean;
+    small?:boolean;
+}
+
+const Button: React.FC<ButtonProps> = ({
+    label,
+    onClick,
+    disabled,
+    outline,
+    small
+}) => {
+    return (
+        <button
+          type='submit'
+          disabled={disabled}
+          onClick={onClick}
+          className={`
+            relative
+            disabled:opacity-70
+            disabled:cursor-not-allowed
+            rounded-lg
+            hover:opacity-80
+            transition
+            w-full
+            ${outline ? 'bg-white' : 'bg-indigo-500'}
+            ${outline ? 'border-black' : 'border-rose-500'}
+            ${outline ? 'text-black' : 'text-white'}
+            ${small ? 'text-sm' : 'text-md'}          
+            ${small ? 'py-1' : 'py-3'}          
+            ${small ? 'font-lignt' : 'font-semibold'}          
+            ${small ? 'border-[1px]' : 'border-2'}          
+          `}
+        >
+            {label}
+        </button>
+    )
+}
+
+export default Button;

--- a/src/app/components/carousel.tsx
+++ b/src/app/components/carousel.tsx
@@ -1,0 +1,63 @@
+import React, { useState } from 'react';
+import { slideData } from '../assets/data/bookdummy';
+import 'react-responsive-carousel/lib/styles/carousel.min.css';
+import { Carousel } from 'react-responsive-carousel';
+import Link from 'next/link';
+
+const SlideCarousel = () => {
+  const [currentIndex, setCurrentIndex] = useState(0);
+
+  const handleChange = (index:any) => {
+    setCurrentIndex(index);
+  };
+
+  const slidesToShow = 3; // 한 번에 표시할 슬라이드 개수
+
+  const renderSlides = () => {
+    const slides = [];
+
+    for (let i = 0; i < slideData.length; i += slidesToShow) {
+      const chunk = slideData.slice(i, i + slidesToShow);
+      slides.push(
+        <div key={i} className="flex space-x-4">
+          {chunk.map((image, index) => (
+            <div
+              key={index}
+              className="w-80 h-80 border border-slate-200 bg-slate-200 relative"
+            >
+              <img src={image.src} className="h-full" />
+              <div className="absolute transform -translate-y-1/2 md:left-20 top-1/2 mx-8">
+                <div className="text-white text-left">
+                  <h1 className="text-3xl md:text-5xl font-bold">{image.title}</h1>
+                  <p className="py-4 md:text-2xl">{image.content}</p>
+                  <button className="btn">
+                    <Link href="/">바로가기 &#8594;</Link>
+                  </button>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      );
+    }
+
+    return slides;
+  };
+
+  return (
+    <div className="mx-5 my-5">
+      <Carousel
+        showArrows={true}
+        autoPlay={false}
+        infiniteLoop={true}
+        showThumbs={false}
+        selectedItem={currentIndex}
+        onChange={handleChange}
+      >
+        {renderSlides()}
+      </Carousel>
+    </div>
+  );
+};
+
+export default SlideCarousel;

--- a/src/app/components/mapSearch.tsx
+++ b/src/app/components/mapSearch.tsx
@@ -280,7 +280,7 @@ const MapSearch = ({ searchPlace, onMarkerClick }: MapSearchProps): React.ReactE
       {/* 페이지 컨텐츠 및 지도를 표시할 컨테이너 */}
       <div id="map" 
            className='relative'    
-      style={{ width: '100%', height: '800px' }}>
+      style={{ width: '100%', height: '500px' }}>
       {/* 다른 페이지 컨텐츠 */}
       </div>
       <div

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,7 +4,7 @@ import "./globals.css";
 import RecoilRootProvider from '../utils/recoilRootProvider'
 import LoginBtn from "./components/buttons/LoginButton";
 import LogoutButton from "./components/buttons/LogoutButton";
-import NavBar from "./components/NavBar";
+import LayOut from "./components/Layout/Page";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -21,15 +21,14 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={inter.className}>
-        <div>
-        <NavBar/>
+        <LayOut>
           <LoginBtn></LoginBtn>
           <LogoutButton></LogoutButton>
-        </div>
         <RecoilRootProvider>
           {children}
         </RecoilRootProvider>
         <script type="text/javascript" src="//dapi.kakao.com/v2/maps/sdk.js?appkey=6d8ac2fb0740657f1e67a9163c8b331b&autoload=false&libraries=services"></script>
+        </LayOut>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,7 @@ import { useSession } from 'next-auth/react'
 import Image from 'next/image'
 import AddPlace from './components/map'
 import Link from 'next/link'
+import SlideCarousel from './components/carousel'
 
 export default function Home() {
   let session = useSession()
@@ -33,6 +34,7 @@ export default function Home() {
         </>
       )}
       <AddPlace></AddPlace>
+      <SlideCarousel/>
     </div>
   )
 }


### PR DESCRIPTION
전체적인 레이아웃 틀 잡았어요. 와이어프레임 대로 약간 양옆 공백이 있길래 추가했어용 더 반응형으로 수정이 필요할 것 같아요.
버튼 컴포넌트 생성하고 코드 보시구 잘 적용하시면 될거예요 보시고 모르시는 부분 이나 이해안가는 부분 있으시면 말씀해주세요. 그리고 메인화면에 보여지는 내서재 부분 슬라이드 같길래 기능 넣어놨어요 일단 더미로 넣어놨고 스타일은 거의 안잡았어요ㅎㅎ 새로 추가된 부분이라 npm i 하셔야 될 거예요 확인하시구 머지 부탁드려요!